### PR TITLE
Simplifies catching keyboard interrupt

### DIFF
--- a/arduino/arduino.py
+++ b/arduino/arduino.py
@@ -123,9 +123,6 @@ def copy_sketch(source_path = '', destination_path = '.', name = None, overwrite
 # the following methods are just for testing
 # will produce output when this module is run as __main__
 def preload():
-  print()
-  print()
-  print()
   print('preload test')
 
 def setup():
@@ -136,11 +133,7 @@ def loop():
   delay(1000)
 
 def cleanup():
-  print()
   print('cleanup test')
-  print()
-  print()
-
 
 # RUNTIME
 def start(setup=None, loop=None, cleanup = None, preload = None):


### PR DESCRIPTION
This PR simplifies the process of catching the keyboard interrupt error reducing overhead.
Also it adds the option of running the loop non-blocking without delay. To do so the `NON_BLOCKING` property has to be set to `True`:

```py
from arduino import *

arduino.NON_BLOCKING = True

def setup():
  print('setup test')

def loop():
  print('loop test')

def cleanup():
  print('cleanup test')

start(setup, loop, cleanup)
```