### PR TITLE
Reintroduced preload for future use.

### DIFF
--- a/arduino/arduino.py
+++ b/arduino/arduino.py
@@ -111,6 +111,8 @@ def copy_sketch(source_path = '', destination_path = '.', name = None, overwrite
 
 # RUNTIME
 def start(setup=None, loop=None, cleanup = None, preload = None):
+  if preload is not None:
+    preload()
   if setup is not None:
     setup()
   try:

--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
     ["arduino/examples/02_nano_esp32_advanced.py", "github:arduino/arduino-runtime-mpy/arduino/examples/02_nano_esp32_advanced.py"]
   ],
   "deps": [],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
     ["arduino/examples/02_nano_esp32_advanced.py", "github:arduino/arduino-runtime-mpy/arduino/examples/02_nano_esp32_advanced.py"]
   ],
   "deps": [],
-  "version": "0.2.0"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
The `preload()` method is bound to be used for pre-init which is operated by higher level frameworks implementing the Arduino Runtime, hence transparent to the user and not needed to be manually invoked via `setup()`