### PR TITLE
Resolved conflict between map() and Python's map type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This module also wraps machine functions in easy-to-use methods.
 ## Installation
 
 ### mip (MicroPython Package Manager)
+
 This is the recommended method for boards which can connect to Internet.
 Run the following MicroPython script using your favourite editor:
 
@@ -43,7 +44,9 @@ connect(SSID, PWD)
 mip.install('github:arduino/arduino-runtime-mpy')
 
 ```
+
 ### mpremote mip
+
 You will need to have Python and `mpremote` installed on your system, [follow these instructions](https://docs.micropython.org/en/latest/reference/mpremote.html) to do so.
 
 Open a shell and run the following command:
@@ -53,8 +56,8 @@ mpremote mip install "github:arduino/arduino-runtime-mpy"
 ```
 
 ### Manual Installation
-Copy the folder `arduino` and its content into your board's `lib` folder using your preferred method.
 
+Copy the folder `arduino` and its content into your board's `lib` folder using your preferred method.
 
 ## Usage
 
@@ -219,10 +222,10 @@ delay(1000) # Delay the execution for 1 second
 
 Some utility methods are provided and are still in development:
 
-* `map(x, in_min, in_max, out_min, out_max)`
+* `mapf(x, in_min, in_max, out_min, out_max)`
   Remaps the value `x` from its input range to an output range
 * `mapi(x, in_min, in_max, out_min, out_max)`
-  same as `map` but always returns an integer
+  same as `mapf` but always returns an integer
 * `random(low, high=None)`
   Returns a random number between `0` and `low` - 1 if no `high` is provided, otherwise a value between `low` and `high` - 1
 * `constrain(val, min_val, max_val)`
@@ -248,6 +251,6 @@ create_sketch('main')
 
 The method returns the Python file's full path.
 
-### copy_sketch(source_path = '', destination_path = '.', name = None, overwrite = False):
+### copy_sketch(source_path = '', destination_path = '.', name = None, overwrite = False)
 
 Wraps `create_sketch()` and provides a shortcut to copy a file to another path.

--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ delay(1000) # Delay the execution for 1 second
 
 Some utility methods are provided and are still in development:
 
-* `mapf(x, in_min, in_max, out_min, out_max)`
+* `map_float(x, in_min, in_max, out_min, out_max)`
   Remaps the value `x` from its input range to an output range
-* `mapi(x, in_min, in_max, out_min, out_max)`
-  same as `mapf` but always returns an integer
+* `map_int(x, in_min, in_max, out_min, out_max)`
+  same as `map_float` but always returns an integer
 * `random(low, high=None)`
   Returns a random number between `0` and `low` - 1 if no `high` is provided, otherwise a value between `low` and `high` - 1
 * `constrain(val, min_val, max_val)`

--- a/arduino/__init__.py
+++ b/arduino/__init__.py
@@ -1,7 +1,7 @@
-__author__ = "Murilo Polese"
+__author__ = "Ubi de Feo"
 __credits__ = ["Murilo Polese", "Ubi de Feo", "Sebastian Romero"]
 __license__ = "MPL 2.0"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __maintainer__ = "Arduino"
 
 from .arduino import *

--- a/arduino/arduino.py
+++ b/arduino/arduino.py
@@ -15,11 +15,11 @@ HIGH = 1 # Voltage level HIGH
 LOW = 0 # Voltage level LOW
 
 # UTILITY
-def map(x, in_min, in_max, out_min, out_max) -> int | float:
+def mapf(x, in_min, in_max, out_min, out_max) -> int | float:
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
 
 def mapi(x, in_min, in_max, out_min, out_max) -> int:
-  return int(map(x, in_min, in_max, out_min, out_max))
+  return int(mapf(x, in_min, in_max, out_min, out_max))
 
 def random(low, high=None) -> int:
   if high == None:
@@ -75,6 +75,10 @@ def analogWrite(_pin, _duty_cycle) -> None:
 def delay(_ms) -> None:
   sleep_ms(_ms)
 
+
+def no_sleep() -> None:
+  global NON_BLOCKING
+  NON_BLOCKING = True
 
 # HELPERS
 

--- a/arduino/arduino.py
+++ b/arduino/arduino.py
@@ -15,10 +15,10 @@ HIGH = 1 # Voltage level HIGH
 LOW = 0 # Voltage level LOW
 
 # UTILITY
-def mapf(x, in_min, in_max, out_min, out_max) -> int | float:
+def map_float(x, in_min, in_max, out_min, out_max) -> int | float:
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
 
-def mapi(x, in_min, in_max, out_min, out_max) -> int:
+def map_int(x, in_min, in_max, out_min, out_max) -> int:
   return int(mapf(x, in_min, in_max, out_min, out_max))
 
 def random(low, high=None) -> int:


### PR DESCRIPTION
Python's native `map` type was in conflict with the `map()` function returning a float.
`mapf()` conforms to the style of `mapi()` and addresses this issue